### PR TITLE
Update responsiveness to FourZeroFour component

### DIFF
--- a/src/components/404Section/FourZeroFour.jsx
+++ b/src/components/404Section/FourZeroFour.jsx
@@ -3,26 +3,19 @@ import fourZeroFourImage from "./404_img.png";
 export default function FourZeroFour({ options }) {
     const {buttonText, buttonLink, gradient} = options;
     return (
-        <div className="lg:w-[984px] md:h-[351.6px]
-                        md:w-[831px] md:h-[320px]
-                        sm:w-[340px] md:h-[513.21px]
-                        md:flex mx-auto md:content-center md:items-center">
-            <div className="flex-1"></div>
-            <div className="flex-none w-5/6">
-                <div className="flex w-full">
-                    <div className="flex-auto">
-                        <img className="lg:w-[566] lg:h-[351.6] md:w-[480] md:h-[298] sm:w-[340] sm:h-[211]" src={fourZeroFourImage}></img>
-                    </div>
-                    <div className="flex-1 my-auto mx-auto items-center content-center justify-center">
-                        <p className="font-main text-8xl dark:text-white text-black">404</p>
-                        <p className="font-main text-2xl sm:text-1x1 py-4 leading-tight dark:text-white text-black">Page not found</p>
-                        <button className={`w-[200px] h-[60px] rounded-[50px] mt-5 bg-gradient-to-r ${gradient}`}>
-                            <a href={buttonLink} className = "font-main dark:text-white text-black">BACK TO HOMEPAGE</a>
-                        </button>
-                    </div>
+        <div className="flex items-center justify-center">  
+            <div className="flex sm:flex-col md:flex-row md:gap-35 sm:gap-20 max-auto">
+                <div className="flex-initial ">
+                    <img className="lg:w-[566] lg:h-[351.6] md:w-[480] md:h-[298] sm:w-[340] sm:h-[211]" src={fourZeroFourImage}></img>
+                </div>
+                <div className="flex-initial">
+                    <p className="font-main flex-auto sm:text-6xl md:text-8xl dark:text-white text-black">404</p>
+                    <p className="font-main md:text-3xl sm:text-2xl py-4 leading-tight dark:text-white text-black">Page not found</p>
+                    <button className={`w-[250px] h-[60px] rounded-[50px] mt-5 bg-gradient-to-r ${gradient}`}>
+                        <a href={buttonLink} className = "font-main dark:text-white text-black">BACK TO HOMEPAGE</a>
+                    </button>
                 </div>
             </div>
-            <div className="flex-1"></div>
         </div>
     )
 }

--- a/src/components/404Section/FourZeroFour.jsx
+++ b/src/components/404Section/FourZeroFour.jsx
@@ -4,7 +4,7 @@ export default function FourZeroFour({ options }) {
     const {buttonText, buttonLink, gradient} = options;
     return (
         <div className="flex items-center justify-center">  
-            <div className="flex flex-col md:flex-row md:gap-35 sm:gap-20 max-auto">
+            <div className="flex flex-col md:flex-row md:gap-35 gap-20 max-auto">
                 <div className="flex-initial ">
                     <img className="lg:w-full md:w-[480] md:h-[298] w-[340] h-[211]" src={fourZeroFourImage}></img>
                 </div>

--- a/src/components/404Section/FourZeroFour.jsx
+++ b/src/components/404Section/FourZeroFour.jsx
@@ -6,12 +6,12 @@ export default function FourZeroFour({ options }) {
         <div className="flex items-center justify-center">  
             <div className="flex sm:flex-col md:flex-row md:gap-35 sm:gap-20 max-auto">
                 <div className="flex-initial ">
-                    <img className="lg:w-[566] lg:h-[351.6] md:w-[480] md:h-[298] sm:w-[340] sm:h-[211]" src={fourZeroFourImage}></img>
+                    <img className="lg:w-full md:w-[480] md:h-[298] sm:w-[340] sm:h-[211]" src={fourZeroFourImage}></img>
                 </div>
                 <div className="flex-initial">
                     <p className="font-main flex-auto sm:text-6xl md:text-8xl dark:text-white text-black">404</p>
                     <p className="font-main md:text-3xl sm:text-2xl py-4 leading-tight dark:text-white text-black">Page not found</p>
-                    <button className={`w-[250px] h-[60px] rounded-[50px] mt-5 bg-gradient-to-r ${gradient}`}>
+                    <button className={`w-[200px] h-[50px] rounded-[50px] mt-5 bg-gradient-to-r ${gradient}`}>
                         <a href={buttonLink} className = "font-main dark:text-white text-black">BACK TO HOMEPAGE</a>
                     </button>
                 </div>

--- a/src/components/404Section/FourZeroFour.jsx
+++ b/src/components/404Section/FourZeroFour.jsx
@@ -4,13 +4,13 @@ export default function FourZeroFour({ options }) {
     const {buttonText, buttonLink, gradient} = options;
     return (
         <div className="flex items-center justify-center">  
-            <div className="flex sm:flex-col md:flex-row md:gap-35 sm:gap-20 max-auto">
+            <div className="flex flex-col md:flex-row md:gap-35 sm:gap-20 max-auto">
                 <div className="flex-initial ">
-                    <img className="lg:w-full md:w-[480] md:h-[298] sm:w-[340] sm:h-[211]" src={fourZeroFourImage}></img>
+                    <img className="lg:w-full md:w-[480] md:h-[298] w-[340] h-[211]" src={fourZeroFourImage}></img>
                 </div>
                 <div className="flex-initial">
-                    <p className="font-main flex-auto sm:text-6xl md:text-8xl dark:text-white text-black">404</p>
-                    <p className="font-main md:text-3xl sm:text-2xl py-4 leading-tight dark:text-white text-black">Page not found</p>
+                    <p className="font-main flex-auto text-6xl md:text-8xl dark:text-white text-black">404</p>
+                    <p className="font-main md:text-3xl text-2xl py-4 leading-tight dark:text-white text-black">Page not found</p>
                     <button className={`w-[200px] h-[50px] rounded-[50px] mt-5 bg-gradient-to-r ${gradient}`}>
                         <a href={buttonLink} className = "font-main dark:text-white text-black">BACK TO HOMEPAGE</a>
                     </button>


### PR DESCRIPTION
add responsiveness to screen size of a phone to 404 component.
So that it looks like this on large screens:
<img width="665" alt="image" src="https://user-images.githubusercontent.com/122959510/229943207-75a54ec1-8df0-417f-bd26-8c63a200f705.png">
and like this on small screens:
<img width="520" alt="image" src="https://user-images.githubusercontent.com/122959510/229941856-3fce3369-0a17-4870-91ff-e717a3ca8870.png">

file changed:
FourZeroFour.jsx
